### PR TITLE
[ENH] add predict_proba() to SentenceClassifier

### DIFF
--- a/src/skeval/classifier/sentence_classifier.py
+++ b/src/skeval/classifier/sentence_classifier.py
@@ -158,6 +158,25 @@ class SentenceClassifier:
                 out.append(self.label_encoder.decode(logits.argmax(1).item()))
         return out
 
+    def predict_proba(self, X: List[str]) -> np.ndarray:
+        """Return class probabilities for each sample, shape (n_samples, n_classes)."""
+        if self.model is None:
+            raise RuntimeError("Model is not fitted. Call fit() or load() first.")
+        _validate_input(X)
+
+        self.model.eval()
+        probs = []
+        with torch.no_grad():
+            for s in X:
+                ids = self.vocab.encode(s)
+                if not ids:
+                    ids = [0]
+                text = torch.tensor(ids, dtype=torch.long, device=self.device)
+                offset = torch.zeros(1, dtype=torch.long, device=self.device)
+                logits = self.model(text, offset)
+                probs.append(torch.softmax(logits, dim=1).cpu().numpy()[0])
+        return np.array(probs)
+
     def score(self, X: List[str], y: List[str]) -> float:
         preds = self.predict(X)
         return sum(p == t for p, t in zip(preds, y)) / len(y)


### PR DESCRIPTION
## Summary
- Adds `predict_proba(X)` method to `SentenceClassifier`
- Returns a `numpy.ndarray` of shape `(n_samples, n_classes)` with softmax probabilities
- ***Enables compatibility with LIME, SHAP, ONNX, and any library expecting probability outputs***

## Test plan
- [ ] `predict_proba()` returns shape `(n_samples, n_classes)`
- [ ] Each row sums to ~1.0
- [ ] Raises `RuntimeError` if called before `fit()`
- [ ] Raises `ValueError` for invalid input

Closes #41