### PR TITLE
[DOC] add GridSearchCV and skore example scripts

### DIFF
--- a/examples/06_gridsearchcv.py
+++ b/examples/06_gridsearchcv.py
@@ -1,0 +1,58 @@
+"""Hyperparameter tuning with GridSearchCV.
+
+SentenceClassifier implements get_params() / set_params() so it works
+directly with sklearn's GridSearchCV.  The search picks the best
+combination of embed_dim, epochs, and lr on cross-validated accuracy.
+"""
+
+from sklearn.model_selection import GridSearchCV
+
+from skeval.classifier import SentenceClassifier
+
+sentences = [
+    "Water boils at 100 degrees Celsius",
+    "Paris is the capital of France",
+    "The moon orbits the Earth",
+    "Light travels at 300,000 km per second",
+    "I am feeling very sad today",
+    "This is the worst day of my life",
+    "I feel so excited right now",
+    "She was overwhelmed with joy",
+    "I think this movie is amazing",
+    "In my opinion, pizza is the best food",
+    "I believe coffee is better than tea",
+    "Personally, I prefer winter over summer",
+    "Please close the door",
+    "Open the window right now",
+    "Turn off the lights",
+    "Send me the report by Monday",
+]
+labels = [
+    "fact", "fact", "fact", "fact",
+    "emotion", "emotion", "emotion", "emotion",
+    "opinion", "opinion", "opinion", "opinion",
+    "instruction", "instruction", "instruction", "instruction",
+]
+
+param_grid = {
+    "embed_dim": [32, 64],
+    "epochs": [20, 40],
+    "lr": [0.005, 0.01],
+}
+
+clf = SentenceClassifier(random_state=42)
+search = GridSearchCV(clf, param_grid, cv=2, scoring="accuracy", n_jobs=1, verbose=1)
+search.fit(sentences, labels)
+
+print(f"\nBest params : {search.best_params_}")
+print(f"Best CV acc : {search.best_score_:.2%}")
+
+test = [
+    "The sky is blue",
+    "I am so happy",
+    "I believe dogs are better than cats",
+    "Turn off the lights",
+]
+preds = search.predict(test)
+for sentence, label in zip(test, preds):
+    print(f"[{label:>12}]  {sentence}")

--- a/examples/07_skore.py
+++ b/examples/07_skore.py
@@ -1,0 +1,75 @@
+"""Tracking experiments with skore.
+
+skore is an open-source ML experiment tracker that works with any
+sklearn-compatible estimator.  This example shows how to log a
+GridSearchCV run and inspect results in the skore UI.
+
+Install skore first:
+    pip install skore
+
+Then launch the UI in a separate terminal:
+    skore launch my_project
+"""
+
+import skore
+from sklearn.model_selection import GridSearchCV, cross_val_score
+
+from skeval.classifier import SentenceClassifier
+
+sentences = [
+    "Water boils at 100 degrees Celsius",
+    "Paris is the capital of France",
+    "The moon orbits the Earth",
+    "Light travels at 300,000 km per second",
+    "I am feeling very sad today",
+    "This is the worst day of my life",
+    "I feel so excited right now",
+    "She was overwhelmed with joy",
+    "I think this movie is amazing",
+    "In my opinion, pizza is the best food",
+    "I believe coffee is better than tea",
+    "Personally, I prefer winter over summer",
+    "Please close the door",
+    "Open the window right now",
+    "Turn off the lights",
+    "Send me the report by Monday",
+]
+labels = [
+    "fact", "fact", "fact", "fact",
+    "emotion", "emotion", "emotion", "emotion",
+    "opinion", "opinion", "opinion", "opinion",
+    "instruction", "instruction", "instruction", "instruction",
+]
+
+# --- open (or create) a skore project ---
+project = skore.open("my_project", overwrite=True)
+
+# --- cross-validated baseline ---
+clf = SentenceClassifier(embed_dim=64, epochs=40, lr=0.01, random_state=42)
+cv_scores = cross_val_score(clf, sentences, labels, cv=2, scoring="accuracy")
+project.put("baseline_cv_accuracy", cv_scores.mean())
+print(f"Baseline CV accuracy: {cv_scores.mean():.2%}")
+
+# --- grid search ---
+param_grid = {
+    "embed_dim": [32, 64],
+    "epochs": [20, 40],
+    "lr": [0.005, 0.01],
+}
+search = GridSearchCV(
+    SentenceClassifier(random_state=42),
+    param_grid,
+    cv=2,
+    scoring="accuracy",
+    n_jobs=1,
+    verbose=0,
+)
+search.fit(sentences, labels)
+
+project.put("best_params", search.best_params_)
+project.put("best_cv_accuracy", search.best_score_)
+
+print(f"Best params  : {search.best_params_}")
+print(f"Best CV acc  : {search.best_score_:.2%}")
+print("\nOpen the skore UI to explore results:")
+print("  skore launch my_project")


### PR DESCRIPTION
## Summary
- Adds `examples/06_gridsearchcv.py` — tunes `embed_dim`, `epochs`, and `lr` via `GridSearchCV` using the sklearn estimator interface
- Adds `examples/07_skore.py` — logs cross-val baseline and grid search results to a skore project for interactive exploration in the skore UI

## Test plan
- [ ] `python examples/06_gridsearchcv.py` runs without errors and prints best params + predictions
- [ ] `python examples/07_skore.py` (with skore installed) creates a project and logs `baseline_cv_accuracy`, `best_params`, `best_cv_accuracy`

Closes #37