### PR TITLE
[DOC] add Read the Docs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs


### PR DESCRIPTION
## Summary
- Adds `.readthedocs.yaml` to enable automatic documentation builds on Read the Docs
- Builds with Python 3.10 on Ubuntu 22.04
- Installs the package with `[docs]` extras (Sphinx, sphinx-rtd-theme, myst-parser)
- Points Sphinx at the existing `docs/conf.py`

## Setup steps (one-time)
1. Go to readthedocs.org and sign in with GitHub
2. Click **Import a Project** and select this repo
3. Read the Docs will pick up `.readthedocs.yaml` automatically
4. Docs will build and deploy on every push to main and every PR

## Test plan
- [ ] Read the Docs build passes after import
- [ ] Documentation is accessible at the generated RTD URL