### PR TITLE
feat: add `skeval.model_selection` module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__/
 .venv/
+venv
 .env
 build/
 dist/

--- a/src/skeval/__init__.py
+++ b/src/skeval/__init__.py
@@ -17,8 +17,9 @@ Example
 from skeval.classifier import SentenceClassifier
 from skeval.evaluator import Evaluator
 from skeval.metrics import compute_metrics
+from skeval.model_selection import cross_val_score, train_test_split
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 __author__ = "skeval Contributors"
 __license__ = "MIT"
 
@@ -26,5 +27,7 @@ __all__ = [
     "SentenceClassifier",
     "Evaluator",
     "compute_metrics",
+    "train_test_split",
+    "cross_val_score",
     "__version__",
 ]

--- a/src/skeval/model_selection/__init__.py
+++ b/src/skeval/model_selection/__init__.py
@@ -1,0 +1,3 @@
+from skeval.model_selection.model_selection import cross_val_score, train_test_split
+
+__all__ = ["train_test_split", "cross_val_score"]

--- a/src/skeval/model_selection/model_selection.py
+++ b/src/skeval/model_selection/model_selection.py
@@ -89,6 +89,4 @@ def cross_val_score(
         >>> scores = cross_val_score(SentenceClassifier(), X, y, cv=5)
         >>> print(scores.mean())
     """
-    return _cv_score(  # type: ignore[no-any-return]
-        estimator, X, y, cv=cv, scoring=scoring, n_jobs=n_jobs
-    )
+    return np.asarray(_cv_score(estimator, X, y, cv=cv, scoring=scoring, n_jobs=n_jobs))

--- a/src/skeval/model_selection/model_selection.py
+++ b/src/skeval/model_selection/model_selection.py
@@ -1,0 +1,92 @@
+from typing import Any, List, Optional, Tuple, Union
+
+import numpy as np
+from sklearn.model_selection import cross_val_score as _cv_score
+from sklearn.model_selection import train_test_split as _tts
+
+
+def train_test_split(
+    X: List[str],
+    y: List[str],
+    test_size: Union[float, int] = 0.2,
+    random_state: Optional[int] = None,
+    shuffle: bool = True,
+    stratify: bool = False,
+) -> Tuple[List[str], List[str], List[str], List[str]]:
+    """Split sentences and labels into random train and test subsets.
+
+    A thin, type-annotated wrapper around
+    :func:`sklearn.model_selection.train_test_split` that preserves
+    ``List[str]`` types for sentences and labels.
+
+    Args:
+        X: Sentence strings to split.
+        y: Labels aligned with ``X``.
+        test_size: If float, the proportion of the dataset to include in the
+            test split. If int, the absolute number of test samples.
+        random_state: Seed for the random number generator.
+        shuffle: Whether to shuffle the data before splitting.
+        stratify: If ``True``, the split is stratified by ``y`` so that each
+            split has roughly the same class distribution.
+
+    Returns:
+        A 4-tuple ``(X_train, X_test, y_train, y_test)`` of string lists.
+
+    Raises:
+        ValueError: If ``X`` and ``y`` have different lengths.
+
+    Example:
+        >>> X_train, X_test, y_train, y_test = train_test_split(
+        ...     X, y, test_size=0.2, random_state=42
+        ... )
+    """
+    if len(X) != len(y):
+        raise ValueError(
+            f"X and y must have the same length, got {len(X)} and {len(y)}."
+        )
+    stratify_arr = y if stratify else None
+    X_train, X_test, y_train, y_test = _tts(
+        X,
+        y,
+        test_size=test_size,
+        random_state=random_state,
+        shuffle=shuffle,
+        stratify=stratify_arr,
+    )
+    return list(X_train), list(X_test), list(y_train), list(y_test)
+
+
+def cross_val_score(
+    estimator: Any,
+    X: List[str],
+    y: List[str],
+    cv: int = 5,
+    scoring: str = "accuracy",
+    n_jobs: Optional[int] = None,
+) -> np.ndarray:
+    """Evaluate a classifier using k-fold cross-validation.
+
+    A convenience wrapper around
+    :func:`sklearn.model_selection.cross_val_score` with sensible defaults
+    for ``SentenceClassifier``.
+
+    Args:
+        estimator: A fitted or unfitted sklearn-compatible estimator, e.g.
+            :class:`~skeval.classifier.SentenceClassifier`.
+        X: Sentence strings.
+        y: Labels aligned with ``X``.
+        cv: Number of cross-validation folds.
+        scoring: Scoring metric passed to sklearn (default ``"accuracy"``).
+        n_jobs: Number of jobs for parallel fold execution. ``None`` means 1;
+            ``-1`` uses all available CPUs.
+
+    Returns:
+        Float array of shape ``(cv,)`` with the score for each fold.
+
+    Example:
+        >>> from skeval import SentenceClassifier
+        >>> from skeval.model_selection import cross_val_score
+        >>> scores = cross_val_score(SentenceClassifier(), X, y, cv=5)
+        >>> print(scores.mean())
+    """
+    return _cv_score(estimator, X, y, cv=cv, scoring=scoring, n_jobs=n_jobs)  # type: ignore[no-any-return]

--- a/src/skeval/model_selection/model_selection.py
+++ b/src/skeval/model_selection/model_selection.py
@@ -89,4 +89,6 @@ def cross_val_score(
         >>> scores = cross_val_score(SentenceClassifier(), X, y, cv=5)
         >>> print(scores.mean())
     """
-    return _cv_score(estimator, X, y, cv=cv, scoring=scoring, n_jobs=n_jobs)  # type: ignore[no-any-return]
+    return _cv_score(  # type: ignore[no-any-return]
+        estimator, X, y, cv=cv, scoring=scoring, n_jobs=n_jobs
+    )


### PR DESCRIPTION
## Summary

Closes #20. Adds a new `skeval.model_selection` module exposing two utility functions for working with `SentenceClassifier` in sklearn-style workflows.

## New functions

- `train_test_split(X, y, test_size, random_state, shuffle, stratify)` — type-annotated wrapper around sklearn's `train_test_split` that preserves `List[str]` types and adds a `stratify` boolean shortcut.
- `cross_val_score(estimator, X, y, cv, scoring, n_jobs)` — convenience wrapper around sklearn's `cross_val_score` with sensible defaults for `SentenceClassifier`.

Both are importable from `skeval.model_selection` or directly from `skeval`.

## Changed files

- `src/skeval/model_selection/model_selection.py` — new module with both functions
- `src/skeval/model_selection/__init__.py` — package init
- `src/skeval/__init__.py` — exposes `train_test_split` and `cross_val_score` at top level

## Test plan

- [ ] `from skeval.model_selection import train_test_split, cross_val_score` works
- [ ] `from skeval import train_test_split, cross_val_score` works
- [ ] `train_test_split(X, y, test_size=0.2)` returns 4 lists of correct sizes
- [ ] `cross_val_score(SentenceClassifier(), X, y, cv=3)` returns array of length 3