### PR TITLE
docs: update documentation for v0.2.0

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -47,6 +47,16 @@ skeval.dataset
 
 ----
 
+skeval.model_selection
+------------------------
+
+.. automodule:: skeval.model_selection.model_selection
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+----
+
 skeval.utils
 --------------
 

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -19,6 +19,8 @@ Module Overview
    │   └── evaluator.py
    ├── metrics/             # Metric computation
    │   └── metrics.py
+   ├── model_selection/     # train_test_split and cross_val_score
+   │   └── model_selection.py
    └── utils/               # Shared building blocks
        └── helpers.py
 
@@ -73,7 +75,7 @@ Builds a bag-of-words vocabulary from a list of sentences. Text is normalized (l
 * ``<PAD>`` at index ``0`` — used as a placeholder for empty inputs
 * ``<UNK>`` at index ``1`` — maps words not seen during training
 
-The ``min_freq`` parameter (default ``1``) filters out rare tokens.
+The ``min_freq`` parameter (default ``1``) filters out rare tokens. The ``word2idx`` and ``idx2word`` mappings are built in a single pass over the corpus for efficiency.
 
 LabelEncoder
 ^^^^^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,7 +45,7 @@ Train a classifier and evaluate it in a few lines:
    ]
    labels = ["fact", "emotion", "opinion", "instruction"]
 
-   classifier.train(sentences, labels, epochs=20)
+   classifier.fit(sentences, labels, epochs=20)
 
    predictions = classifier.predict(["The sky is blue", "I am sad"])
    print(predictions)  # e.g. ['fact', 'emotion']
@@ -61,7 +61,10 @@ Key Features
 
 * **Four semantic categories** out of the box: ``fact``, ``emotion``, ``opinion``, ``instruction``
 * **Custom labels** — bring any label taxonomy you need
+* **sklearn-compatible** — works with ``GridSearchCV``, ``Pipeline``, and ``cross_val_score``
 * **Save / load** trained models to disk
 * **Evaluation metrics** — accuracy, per-class precision / recall / F1, confusion matrix
+* **Probability outputs** — ``predict_proba()`` for LIME, SHAP, and ONNX compatibility
+* **Model selection** — ``train_test_split`` and ``cross_val_score`` in ``skeval.model_selection``
 * **Dataset utilities** — load from CSV or JSON Lines files
 * **Training scripts** — CLI scripts for training and evaluation without writing Python

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -7,13 +7,13 @@ Python API
 Training a Classifier
 ^^^^^^^^^^^^^^^^^^^^^
 
-Create a :class:`~skeval.classifier.SentenceClassifier`, pass your sentences and labels, and call :meth:`~skeval.classifier.SentenceClassifier.train`:
+Create a :class:`~skeval.classifier.SentenceClassifier` and call :meth:`~skeval.classifier.SentenceClassifier.fit`:
 
 .. code-block:: python
 
    from skeval.classifier import SentenceClassifier
 
-   classifier = SentenceClassifier(embed_dim=64)
+   classifier = SentenceClassifier(embed_dim=64, random_state=42)
 
    sentences = [
        "Water boils at 100 degrees Celsius",
@@ -32,9 +32,37 @@ Create a :class:`~skeval.classifier.SentenceClassifier`, pass your sentences and
        "instruction", "instruction",
    ]
 
-   classifier.train(sentences, labels, epochs=20, lr=0.01)
+   classifier.fit(sentences, labels, epochs=20, lr=0.01)
 
 The label vocabulary is inferred automatically from the labels you provide — you are not limited to the four default categories.
+
+Training with Validation Split and Early Stopping
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Pass ``val_split`` to hold out a fraction of training data for validation, and ``patience`` to stop early when validation loss stops improving:
+
+.. code-block:: python
+
+   classifier = SentenceClassifier(
+       embed_dim=64,
+       val_split=0.2,
+       patience=5,
+       random_state=42,
+   )
+   classifier.fit(sentences, labels, epochs=100, lr=0.01)
+
+DataLoader Performance Options
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use ``num_workers`` and ``pin_memory`` to speed up data loading on multi-core machines or when training on GPU:
+
+.. code-block:: python
+
+   classifier = SentenceClassifier(
+       embed_dim=64,
+       num_workers=4,
+       pin_memory=True,
+   )
 
 Making Predictions
 ^^^^^^^^^^^^^^^^^^
@@ -51,6 +79,56 @@ Making Predictions
    ])
    print(predictions)
    # ['fact', 'emotion', 'opinion', 'instruction']
+
+Probability Outputs
+^^^^^^^^^^^^^^^^^^^
+
+:meth:`~skeval.classifier.SentenceClassifier.predict_proba` returns a ``(n_samples, n_classes)`` NumPy array of softmax probabilities, compatible with LIME, SHAP, and ONNX:
+
+.. code-block:: python
+
+   proba = classifier.predict_proba([
+       "The sky is blue",
+       "I am so happy",
+   ])
+   print(proba.shape)   # (2, 4)
+   print(proba[0])      # e.g. [0.82, 0.05, 0.08, 0.05]
+
+Model Selection
+^^^^^^^^^^^^^^^
+
+Use :mod:`skeval.model_selection` for splitting data and cross-validating:
+
+.. code-block:: python
+
+   from skeval.model_selection import train_test_split, cross_val_score
+   from skeval.classifier import SentenceClassifier
+
+   X_train, X_test, y_train, y_test = train_test_split(
+       sentences, labels, test_size=0.25, random_state=42, stratify=True
+   )
+
+   clf = SentenceClassifier(embed_dim=64, epochs=20, random_state=0)
+   scores = cross_val_score(clf, sentences, labels, cv=4)
+   print(scores)          # e.g. [0.75, 0.88, 0.62, 0.75]
+   print(scores.mean())   # e.g. 0.75
+
+sklearn Integration
+^^^^^^^^^^^^^^^^^^^
+
+:class:`~skeval.classifier.SentenceClassifier` inherits from ``sklearn.base.BaseEstimator``, making it compatible with sklearn pipelines and ``GridSearchCV``:
+
+.. code-block:: python
+
+   from sklearn.model_selection import GridSearchCV
+   from skeval.classifier import SentenceClassifier
+
+   param_grid = {"embed_dim": [32, 64, 128], "epochs": [10, 20]}
+   grid = GridSearchCV(
+       SentenceClassifier(random_state=0), param_grid, cv=3
+   )
+   grid.fit(sentences, labels)
+   print(grid.best_params_)
 
 Saving and Loading
 ^^^^^^^^^^^^^^^^^^
@@ -130,7 +208,7 @@ Use :class:`~skeval.dataset.loader.DatasetLoader` to read CSV or JSON Lines file
        "data/train.jsonl", text_key="text", label_key="label"
    )
 
-   classifier.train(sentences, labels)
+   classifier.fit(sentences, labels)
 
 ----
 


### PR DESCRIPTION
Updates docs to reflect all v0.2.0 changes:

- Replace deprecated `train()` with `fit()` in quickstart examples
- Add docs for new `__init__` params: `val_split`, `patience`, `num_workers`, `pin_memory`, `random_state`
- Add `predict_proba()` usage section
- Add `skeval.model_selection` examples (`train_test_split`, `cross_val_score`)
- Add sklearn integration section (`GridSearchCV`)
- Add `skeval.model_selection` to API reference
- Update module overview in architecture to include `model_selection/`
- Update `VocabBuilder` description to mention single-pass build
- Update Key Features list on index page