### PR TITLE
docs: update contributing issue links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ All tests must pass before a PR can be merged. New features require new tests. C
 
 ## Reporting bugs
 
-Open a [GitHub issue](https://github.com/direkkakkar319-ops/skeval/issues/new?template=bug_report.md) using the bug report template. Include:
+Open a [GitHub issue](https://github.com/skeval-ai/skeval/issues/new?template=bug_report.md) using the bug report template. Include:
 
 - What you did
 - What you expected to happen
@@ -121,7 +121,7 @@ Open a [GitHub issue](https://github.com/direkkakkar319-ops/skeval/issues/new?te
 
 ## Suggesting features
 
-Open a [GitHub issue](https://github.com/direkkakkar319-ops/skeval/issues/new?template=feature_request.md) using the feature request template. Describe:
+Open a [GitHub issue](https://github.com/skeval-ai/skeval/issues/new?template=feature_request.md) using the feature request template. Describe:
 
 - The problem you are trying to solve
 - Your proposed solution


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #74

#### What does this implement/fix? Explain your changes.
Updates the bug report and feature request issue links in `CONTRIBUTING.md` from the previous `direkkakkar319-ops/skeval` repository path to the current `skeval-ai/skeval` repository path.

#### AI usage disclosure
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [x] Documentation (including examples)
- [x] Research and understanding

#### Any other comments?
Validation:
- `git diff --check`
- `rg -n "direkkakkar319-ops/skeval/issues" CONTRIBUTING.md` returned no matches
- `rg -n "skeval-ai/skeval/issues/new" CONTRIBUTING.md`

Full test suite was not run because this only updates documentation links.