### PR TITLE
fix: update CONTRIBUTING.md links to correct repository URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ All tests must pass before a PR can be merged. New features require new tests. C
 
 ## Reporting bugs
 
-Open a [GitHub issue](https://github.com/direkkakkar319-ops/skeval/issues/new?template=bug_report.md) using the bug report template. Include:
+Open a [GitHub issue](https://github.com/skeval-ai/skeval/issues/new?template=bug_report.md) using the bug report template. Include:
 
 - What you did
 - What you expected to happen
@@ -121,7 +121,7 @@ Open a [GitHub issue](https://github.com/direkkakkar319-ops/skeval/issues/new?te
 
 ## Suggesting features
 
-Open a [GitHub issue](https://github.com/direkkakkar319-ops/skeval/issues/new?template=feature_request.md) using the feature request template. Describe:
+Open a [GitHub issue](https://github.com/skeval-ai/skeval/issues/new?template=feature_request.md) using the feature request template. Describe:
 
 - The problem you are trying to solve
 - Your proposed solution


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:

-->

#### Reference Issues/PRs
Fixes #74

#### What does this implement/fix? Explain your changes.
Two links in `CONTRIBUTING.md` (lines 113 and 124) were pointing to the old 
repository URL (`direkkakkar319-ops/skeval/issues`). Updated both to the correct 
URL (`skeval-ai/skeval/issues`).
#### AI usage disclosure
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [x] Documentation (including examples)
- [ ] Research and understanding

#### Any other comments?
Small docs-only change — no logic, tests, or functionality affected.

#### Any other comments?


<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.

Thanks for contributing!
-->
