### PR TITLE
docs(skeval/README.md): Fix README clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ skeval/
 ## ⚙️ Installation
 
 ```bash
-git clone github.com/direkkakkar319-ops/skeval
+git clone https://github.com/skeval-ai/skeval.git
 cd skeval
 pip install -e .
 ```


### PR DESCRIPTION
Summary:
- Update the README clone command to use the current skeval-ai/skeval repository URL.

Testing:
- Not run; documentation-only change.

Fixes #73