### PR TITLE
fix(skeval/cli): replace remaining Sentinel AI label in CLI description

### DIFF
--- a/src/skeval/cli.py
+++ b/src/skeval/cli.py
@@ -79,7 +79,7 @@ def _evaluate(args: argparse.Namespace) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog="skeval",
-        description="Sentinel AI — Semantic Evaluation Layer for LLMs",
+        description="skeval — Semantic Evaluation Layer for LLMs",
     )
     parser.add_argument("--version", action="version", version="skeval-ai 0.2.0")
     subparsers = parser.add_subparsers(dest="command", metavar="<command>")


### PR DESCRIPTION
## Summary
- Replaces the leftover `Sentinel AI` branding in `src/skeval/cli.py`'s argparse description (line 82) with `skeval`, exactly as requested in #75.
- Single-line change. The `prog="skeval"` and `--version` action elsewhere in the same parser were already correct.

## Verification
- Inspected `skeval --help` output expectation: header now reads `skeval — Semantic Evaluation Layer for LLMs`.
- `python -c "import argparse; ..."` smoke-check on the modified file imports cleanly.

## Context
Splitting [#84](https://github.com/skeval-ai/skeval/pull/84) per @direkkakkar319-ops' request. The other three issues will follow as individual PRs once this one is merged, to keep PR noise low.

Closes #75

## Note
Co-developed with AI assistance; reviewed and tested by submitter.