### PR TITLE
chore(skeval/PULL_REQUEST_TEMPLATE.md): Remove scikit-learn PR template footer

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,9 +33,6 @@ I used AI assistance for:
 
 
 <!--
-Thank you for your patience. Changes to scikit-learn require careful
-attention, but with limited maintainer time, not every contribution can be reviewed
-quickly.
-
-Thanks for contributing!
+Thanks for contributing to skeval. Please keep PRs focused and include the
+relevant validation commands for code or documentation changes.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,4 +35,5 @@ I used AI assistance for:
 <!--
 Thanks for contributing to skeval. Please keep PRs focused and include the
 relevant validation commands for code or documentation changes.
+Thanks for contributing!
 -->


### PR DESCRIPTION
Summary:
- Replace the copied scikit-learn footer in the PR template with skeval-specific guidance.

Testing:
- Not run; template-only change.

Fixes #79