### PR TITLE
fix(skeval/scripts): replace remaining `Sentinel AI` label in `train_model` description

### DIFF
--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -8,7 +8,7 @@ from skeval.dataset.loader import DatasetLoader
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Train a Sentinel AI Sentence Classifier"
+        description="Train a skeval Sentence Classifier"
     )
     parser.add_argument(
         "--data", required=True, type=str, help="Path to training data (.csv or .jsonl)"


### PR DESCRIPTION
## Summary
- Replaces the leftover `Sentinel AI` branding in `scripts/train_model.py`'s argparse description (line 11) with `skeval`, exactly as requested in #76.
- Single-line change.

## Verification
- `python -c "import argparse; p = argparse.ArgumentParser(description='Train a skeval Sentence Classifier'); print(p.format_help())"` shows the corrected header.

## Context
Second in the per-issue split from [#84](https://github.com/skeval-ai/skeval/pull/84) per @direkkakkar319-ops' request. #75 landed in #87 (thanks!); #77 and #81 will follow as separate PRs as this one merges.

Closes #76

## Note
Co-developed with AI assistance; reviewed and tested by submitter.