### PR TITLE
fix(skeval/scripts): replace remaining `Sentinel AI` label in `evaluate_llm` description

### DIFF
--- a/scripts/evaluate_llm.py
+++ b/scripts/evaluate_llm.py
@@ -10,7 +10,7 @@ from skeval.evaluator import Evaluator
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Evaluate a Sentinel AI Sentence Classifier"
+        description="Evaluate a skeval Sentence Classifier"
     )
     parser.add_argument(
         "--model-dir",


### PR DESCRIPTION
## Summary
- Replaces the leftover `Sentinel AI` branding in `scripts/evaluate_llm.py`'s argparse description (line 13) with `skeval`, exactly as requested in #77.
- Single-line change.

## Context
Third in the per-issue split from [#84](https://github.com/skeval-ai/skeval/pull/84) per @direkkakkar319-ops' request. #75 landed in #87, #76 landed in #92 (thanks!); #81 will follow as the final PR once this one merges.

Closes #77

## Note
Co-developed with AI assistance; reviewed and tested by submitter.