### PR TITLE
fix(examples): replace remaining Sentinel AI label in 04_custom_labels docstring (#81)

### DIFF
--- a/examples/04_custom_labels.py
+++ b/examples/04_custom_labels.py
@@ -1,6 +1,6 @@
 """Use a custom label taxonomy instead of the four defaults.
 
-Sentinel AI imposes no fixed label set — you define the categories
+skeval imposes no fixed label set — you define the categories
 by what you put in your training data.
 """
 


### PR DESCRIPTION
## Summary
- Replaces the leftover `Sentinel AI` branding in `examples/04_custom_labels.py`'s top-of-file docstring (line 3) with `skeval`, exactly as requested in #81.
- Single-line change.

## Context
**Final** PR in the per-issue split from [#84](https://github.com/skeval-ai/skeval/pull/84) per @direkkakkar319-ops' request. Sequence:

- #75 → #87 ✅
- #76 → #92 ✅
- #77 → #94 ✅
- #81 → this PR

After this lands, the four `Sentinel AI` occurrences flagged across those issues are all cleared.

Closes #81

## Note
Co-developed with AI assistance; reviewed and tested by submitter.