### PR TITLE
docs(skeval/README.md): add documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Inspired by the need for better semantic evaluation in modern LLM systems.
 
 ## 📖 Documentation
 
-Full documentation and changelog: [https://skeval.readthedocs.io/en/latest/changelog.html](https://skeval.readthedocs.io/en/latest/changelog.html)
+Full documentation and changelog: [https://skeval.readthedocs.io/en/latest/index.html](https://skeval.readthedocs.io/en/latest/changelog.html)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,12 @@ Inspired by the need for better semantic evaluation in modern LLM systems.
 
 ---
 
+## 📖 Documentation
+
+Full documentation and changelog: [https://skeval.readthedocs.io/en/latest/changelog.html](https://skeval.readthedocs.io/en/latest/changelog.html)
+
+---
+
 ## 🔥 Tagline
 
 > *“Not just what the model says—but what it means.”*


### PR DESCRIPTION
Fixes #98

Added the documentation link https://skeval.readthedocs.io/en/latest/changelog.html to README.md