### PR TITLE
docs: add documentation changelog link to README.md (#98)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ print(results)
 
 Full documentation (Sphinx-based) is available in the `docs/` directory.
 
+📖 **[Changelog](https://skeval.readthedocs.io/en/latest/changelog.html)** — See the latest changes and release notes.
+
 To build locally:
 
 ```bash


### PR DESCRIPTION
This PR adds a direct link to the [Skeval Changelog](https://skeval.readthedocs.io/en/latest/changelog.html) in the Documentation section of the README.

Closes #98