### PR TITLE
docs: Autopilot proposal for docs: add documentation link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,3 +190,6 @@ Inspired by the need for better semantic evaluation in modern LLM systems.
 ## 🔥 Tagline
 
 > *“Not just what the model says—but what it means.”*
+
+## Documentation
+- [README](https://skeval.readthedocs.io/en/latest/changelog.html`)


### PR DESCRIPTION
## Summary
Added requested documentation link to README.md.

## Safety
Autopilot is restricted to docs-only paths (README.md, docs/, ops/). No merge, reviewer request, comments, claims, or payment actions are performed.

_No code behavior changes. Documentation-only update._