### PR TITLE
fix(skeval/scripts): use `fit()` in `train_model`

### DIFF
--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -60,10 +60,13 @@ def main():
 
     print(f"Loaded {len(sentences)} training samples.")
 
-    classifier = SentenceClassifier(embed_dim=args.embed_dim)
-    classifier.train(
-        sentences, labels, epochs=args.epochs, batch_size=args.batch_size, lr=args.lr
+    classifier = SentenceClassifier(
+        embed_dim=args.embed_dim,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        lr=args.lr,
     )
+    classifier.fit(sentences, labels)
 
     print(f"Saving model to {args.save_dir}...")
     classifier.save(args.save_dir)

--- a/tests/test_train_model_script.py
+++ b/tests/test_train_model_script.py
@@ -28,6 +28,7 @@ def test_train_model_main_uses_fit_with_constructor_hyperparams(monkeypatch, tmp
     calls = {}
 
     class FakeDatasetLoader:
+        """Loads fake data for testing."""
         @staticmethod
         def load_csv(path, text_col, label_col):
             calls["load_csv"] = (path, text_col, label_col)

--- a/tests/test_train_model_script.py
+++ b/tests/test_train_model_script.py
@@ -31,7 +31,7 @@ def test_train_model_main_uses_fit_with_constructor_hyperparams(monkeypatch, tmp
         @staticmethod
         def load_csv(path, text_col, label_col):
             calls["load_csv"] = (path, text_col, label_col)
-            return ["hello", "bye"], ["fact", "greeting"]
+            return ["Sun rises from east", "I am feeling happy"], ["fact","emotion"]
 
     class FakeSentenceClassifier:
         def __init__(self, **kwargs):

--- a/tests/test_train_model_script.py
+++ b/tests/test_train_model_script.py
@@ -41,6 +41,7 @@ def test_train_model_main_uses_fit_with_constructor_hyperparams(monkeypatch, tmp
             calls["init"] = kwargs
 
         def train(self, *args, **kwargs):
+            """Main guard for the test, crashes if deprecated `train()` is called."""
             raise AssertionError("Deprecated train() should not be used")
 
         def fit(self, sentences, labels):

--- a/tests/test_train_model_script.py
+++ b/tests/test_train_model_script.py
@@ -88,5 +88,5 @@ def test_train_model_main_uses_fit_with_constructor_hyperparams(monkeypatch, tmp
         "batch_size": 3,
         "lr": 0.1,
     }
-    assert calls["fit"] == (["hello", "bye"], ["fact", "greeting"])
+    assert calls["fit"] == (["Sun rises from east", "I am feeling happy"], ["fact", "emotion"])
     assert calls["save"] == str(save_dir)

--- a/tests/test_train_model_script.py
+++ b/tests/test_train_model_script.py
@@ -44,6 +44,7 @@ def test_train_model_main_uses_fit_with_constructor_hyperparams(monkeypatch, tmp
             raise AssertionError("Deprecated train() should not be used")
 
         def fit(self, sentences, labels):
+            """Records sentences and labels when the script calls `fit()`"""
             calls["fit"] = (sentences, labels)
             return self
 

--- a/tests/test_train_model_script.py
+++ b/tests/test_train_model_script.py
@@ -1,0 +1,84 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def load_train_model_module():
+    repo_root = Path(__file__).parents[1]
+    module_path = repo_root / "scripts" / "train_model.py"
+    src_path = str(repo_root / "src")
+    if src_path not in sys.path:
+        sys.path.insert(0, src_path)
+    spec = importlib.util.spec_from_file_location("train_model", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_train_model_main_uses_fit_with_constructor_hyperparams(monkeypatch, tmp_path):
+    module = load_train_model_module()
+    data_file = tmp_path / "train.csv"
+    data_file.write_text("text,label\nhello,fact\nbye,greeting\n", encoding="utf-8")
+    save_dir = tmp_path / "model"
+    calls = {}
+
+    class FakeDatasetLoader:
+        @staticmethod
+        def load_csv(path, text_col, label_col):
+            calls["load_csv"] = (path, text_col, label_col)
+            return ["hello", "bye"], ["fact", "greeting"]
+
+    class FakeSentenceClassifier:
+        def __init__(self, **kwargs):
+            calls["init"] = kwargs
+
+        def train(self, *args, **kwargs):
+            raise AssertionError("Deprecated train() should not be used")
+
+        def fit(self, sentences, labels):
+            calls["fit"] = (sentences, labels)
+            return self
+
+        def save(self, save_path):
+            calls["save"] = save_path
+
+    monkeypatch.setattr(module, "DatasetLoader", FakeDatasetLoader)
+    monkeypatch.setattr(module, "SentenceClassifier", FakeSentenceClassifier)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "train_model.py",
+            "--data",
+            str(data_file),
+            "--text-col",
+            "text",
+            "--label-col",
+            "label",
+            "--save-dir",
+            str(save_dir),
+            "--embed-dim",
+            "12",
+            "--epochs",
+            "7",
+            "--batch-size",
+            "3",
+            "--lr",
+            "0.1",
+        ],
+    )
+
+    module.main()
+
+    assert calls["load_csv"] == (str(data_file), "text", "label")
+    assert calls["init"] == {
+        "embed_dim": 12,
+        "epochs": 7,
+        "batch_size": 3,
+        "lr": 0.1,
+    }
+    assert calls["fit"] == (["hello", "bye"], ["fact", "greeting"])
+    assert calls["save"] == str(save_dir)

--- a/tests/test_train_model_script.py
+++ b/tests/test_train_model_script.py
@@ -19,6 +19,7 @@ def load_train_model_module():
 
 
 def test_train_model_main_uses_fit_with_constructor_hyperparams(monkeypatch, tmp_path):
+    """Verify `main()` calls `fit()` with constructor hyperparams and never calls `train()`."""
     module = load_train_model_module()
     data_file = tmp_path / "train.csv"
     data_file.write_text("text,label\nhello,fact\nbye,greeting\n", encoding="utf-8")

--- a/tests/test_train_model_script.py
+++ b/tests/test_train_model_script.py
@@ -36,6 +36,7 @@ def test_train_model_main_uses_fit_with_constructor_hyperparams(monkeypatch, tmp
             return ["Sun rises from east", "I am feeling happy"], ["fact","emotion"]
 
     class FakeSentenceClassifier:
+        """Replaces `SentenceClassifier` during the test"""
         def __init__(self, **kwargs):
             calls["init"] = kwargs
 

--- a/tests/test_train_model_script.py
+++ b/tests/test_train_model_script.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 
 def load_train_model_module():
+    """Loads `train_model.py` as an importable module."""
     repo_root = Path(__file__).parents[1]
     module_path = repo_root / "scripts" / "train_model.py"
     src_path = str(repo_root / "src")

--- a/tests/test_train_model_script.py
+++ b/tests/test_train_model_script.py
@@ -20,7 +20,7 @@ def load_train_model_module():
 
 
 def test_train_model_main_uses_fit_with_constructor_hyperparams(monkeypatch, tmp_path):
-    """Verify `main()` calls `fit()` with constructor hyperparams and never calls `train()`."""
+    """Verify `main()` calls `fit()` with constructor hyperparams and never calls `train()`."""  # noqa: E501
     module = load_train_model_module()
     data_file = tmp_path / "train.csv"
     data_file.write_text(

--- a/tests/test_train_model_script.py
+++ b/tests/test_train_model_script.py
@@ -31,6 +31,7 @@ def test_train_model_main_uses_fit_with_constructor_hyperparams(monkeypatch, tmp
         """Loads fake data for testing."""
         @staticmethod
         def load_csv(path, text_col, label_col):
+            """Record the call arguments and return fake sentences and labels."""
             calls["load_csv"] = (path, text_col, label_col)
             return ["Sun rises from east", "I am feeling happy"], ["fact","emotion"]
 

--- a/tests/test_train_model_script.py
+++ b/tests/test_train_model_script.py
@@ -43,6 +43,7 @@ def test_train_model_main_uses_fit_with_constructor_hyperparams(monkeypatch, tmp
             return self
 
         def save(self, save_path):
+            """Records `.save()` was called and with what path"""        
             calls["save"] = save_path
 
     monkeypatch.setattr(module, "DatasetLoader", FakeDatasetLoader)

--- a/tests/test_train_model_script.py
+++ b/tests/test_train_model_script.py
@@ -23,20 +23,25 @@ def test_train_model_main_uses_fit_with_constructor_hyperparams(monkeypatch, tmp
     """Verify `main()` calls `fit()` with constructor hyperparams and never calls `train()`."""
     module = load_train_model_module()
     data_file = tmp_path / "train.csv"
-    data_file.write_text("text,label\nSun rises from east,fact\nI am feeling happy,emotion\n", encoding="utf-8")
+    data_file.write_text(
+        "text,label\nSun rises from east,fact\nI am feeling happy,emotion\n",
+        encoding="utf-8",
+    )
     save_dir = tmp_path / "model"
     calls = {}
 
     class FakeDatasetLoader:
         """Loads fake data for testing."""
+
         @staticmethod
         def load_csv(path, text_col, label_col):
             """Record the call arguments and return fake sentences and labels."""
             calls["load_csv"] = (path, text_col, label_col)
-            return ["Sun rises from east", "I am feeling happy"], ["fact","emotion"]
+            return ["Sun rises from east", "I am feeling happy"], ["fact", "emotion"]
 
     class FakeSentenceClassifier:
-        """Replaces `SentenceClassifier` during the test"""
+        """Replaces `SentenceClassifier` during the test."""
+
         def __init__(self, **kwargs):
             calls["init"] = kwargs
 
@@ -45,12 +50,12 @@ def test_train_model_main_uses_fit_with_constructor_hyperparams(monkeypatch, tmp
             raise AssertionError("Deprecated train() should not be used")
 
         def fit(self, sentences, labels):
-            """Records sentences and labels when the script calls `fit()`"""
+            """Records sentences and labels when the script calls `fit()`."""
             calls["fit"] = (sentences, labels)
             return self
 
         def save(self, save_path):
-            """Records `.save()` was called and with what path"""        
+            """Records `.save()` was called and with what path."""
             calls["save"] = save_path
 
     monkeypatch.setattr(module, "DatasetLoader", FakeDatasetLoader)
@@ -88,5 +93,8 @@ def test_train_model_main_uses_fit_with_constructor_hyperparams(monkeypatch, tmp
         "batch_size": 3,
         "lr": 0.1,
     }
-    assert calls["fit"] == (["Sun rises from east", "I am feeling happy"], ["fact", "emotion"])
+    assert calls["fit"] == (
+        ["Sun rises from east", "I am feeling happy"],
+        ["fact", "emotion"],
+    )
     assert calls["save"] == str(save_dir)

--- a/tests/test_train_model_script.py
+++ b/tests/test_train_model_script.py
@@ -23,7 +23,7 @@ def test_train_model_main_uses_fit_with_constructor_hyperparams(monkeypatch, tmp
     """Verify `main()` calls `fit()` with constructor hyperparams and never calls `train()`."""
     module = load_train_model_module()
     data_file = tmp_path / "train.csv"
-    data_file.write_text("text,label\nhello,fact\nbye,greeting\n", encoding="utf-8")
+    data_file.write_text("text,label\nSun rises from east,fact\nI am feeling happy,emotion\n", encoding="utf-8")
     save_dir = tmp_path / "model"
     calls = {}
 


### PR DESCRIPTION
Fixes #110

## Summary
- initialize `SentenceClassifier` with the CLI training hyperparameters
- call `fit(sentences, labels)` in `scripts/train_model.py` instead of the deprecated `train()` wrapper
- add a script-level test that fails if the CLI goes back through `train()`

## Bug verification
- Temporarily reverted the script change with the new test present; it failed with `AssertionError: Deprecated train() should not be used`

## Validation
- `python -m pytest tests/test_train_model_script.py`
- `$env:PYTHONPATH = 'src'; python -m pytest`

Note: `python -m pytest` without `PYTHONPATH=src` fails in this local checkout because the package is not installed editable and existing tests cannot import `skeval`.