### PR TITLE
fix(skeval/dataset): validate CSV columns before loading

### DIFF
--- a/src/skeval/dataset/loader.py
+++ b/src/skeval/dataset/loader.py
@@ -114,6 +114,16 @@ class DatasetLoader:
             A 2-tuple ``(sentences, labels)`` of equal-length string lists.
         """
         df = pd.read_csv(filepath)
+        missing_columns = [
+            col for col in (text_col, label_col) if col not in df.columns
+        ]
+        if missing_columns:
+            available_columns = ", ".join(str(col) for col in df.columns)
+            missing = ", ".join(missing_columns)
+            raise ValueError(
+                f"Missing required CSV column(s): {missing}. "
+                f"Available columns: {available_columns}"
+            )
         return df[text_col].tolist(), df[label_col].tolist()
 
     @staticmethod

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -177,6 +177,19 @@ def test_dataset_loader_csv(tmp_path):
     assert labels == ["fact", "emotion"]
 
 
+def test_dataset_loader_csv_missing_columns(tmp_path):
+    """load_csv() should report requested and available columns when missing."""
+    csv_file = tmp_path / "data.csv"
+    df = pd.DataFrame({"body": ["s1"], "target": ["fact"]})
+    df.to_csv(csv_file, index=False)
+
+    with pytest.raises(ValueError, match="Missing required CSV column\\(s\\): text"):
+        DatasetLoader.load_csv(str(csv_file), "text", "label")
+
+    with pytest.raises(ValueError, match="Available columns: body, target"):
+        DatasetLoader.load_csv(str(csv_file), "text", "label")
+
+
 def test_dataset_loader_json(tmp_path):
     """load_json() should parse text and label keys from a JSONL file."""
     json_file = tmp_path / "data.jsonl"

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -183,11 +183,12 @@ def test_dataset_loader_csv_missing_columns(tmp_path):
     df = pd.DataFrame({"body": ["s1"], "target": ["fact"]})
     df.to_csv(csv_file, index=False)
 
-    with pytest.raises(ValueError, match="Missing required CSV column\\(s\\): text"):
+    with pytest.raises(ValueError) as exc_info:
         DatasetLoader.load_csv(str(csv_file), "text", "label")
 
-    with pytest.raises(ValueError, match="Available columns: body, target"):
-        DatasetLoader.load_csv(str(csv_file), "text", "label")
+    error_message = str(exc_info.value)
+    assert "Missing required CSV column(s): text, label" in error_message
+    assert "Available columns: body, target" in error_message
 
 
 def test_dataset_loader_json(tmp_path):


### PR DESCRIPTION
Fixes #117

## Summary
- validate requested CSV text/label columns before indexing the DataFrame
- raise a descriptive `ValueError` that lists both missing and available columns
- add coverage for the missing-column error path

## Validation
- `PYTHONPATH=src TMP=.pytest-tmp TEMP=.pytest-tmp TMPDIR=.pytest-tmp python -m pytest tests/test_loader.py`
- `PYTHONPATH=src TMP=.pytest-tmp TEMP=.pytest-tmp TMPDIR=.pytest-tmp python -m pytest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CSV loading now validates required columns before processing and provides detailed error messages listing missing and available columns.

* **Tests**
  * Added test coverage for CSV column validation error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/skeval-ai/skeval/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->