### PR TITLE
fix(skeval/dataset): report JSONL load errors clearly

### DIFF
--- a/src/skeval/dataset/loader.py
+++ b/src/skeval/dataset/loader.py
@@ -135,8 +135,25 @@ class DatasetLoader:
         sentences: List[str] = []
         labels: List[str] = []
         with open(filepath, "r", encoding="utf-8") as f:
-            for line in f:
-                data = json.loads(line)
+            for line_num, line in enumerate(f, start=1):
+                try:
+                    data = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    raise ValueError(
+                        f"Malformed JSON on line {line_num}: {exc.msg}"
+                    ) from exc
+
+                missing_keys = [
+                    key for key in (text_key, label_key) if key not in data
+                ]
+                if missing_keys:
+                    missing = ", ".join(missing_keys)
+                    expected = ", ".join((text_key, label_key))
+                    raise ValueError(
+                        f"Missing required JSON key(s) on line {line_num}: "
+                        f"{missing}. Expected keys: {expected}"
+                    )
+
                 sentences.append(data[text_key])
                 labels.append(data[label_key])
         return sentences, labels

--- a/src/skeval/dataset/loader.py
+++ b/src/skeval/dataset/loader.py
@@ -143,9 +143,7 @@ class DatasetLoader:
                         f"Malformed JSON on line {line_num}: {exc.msg}"
                     ) from exc
 
-                missing_keys = [
-                    key for key in (text_key, label_key) if key not in data
-                ]
+                missing_keys = [key for key in (text_key, label_key) if key not in data]
                 if missing_keys:
                     missing = ", ".join(missing_keys)
                     expected = ", ".join((text_key, label_key))

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -188,6 +188,30 @@ def test_dataset_loader_json(tmp_path):
     assert labels == ["fact", "emotion"]
 
 
+def test_dataset_loader_json_reports_malformed_line(tmp_path):
+    """load_json() should report the line number for malformed JSONL input."""
+    json_file = tmp_path / "data.jsonl"
+    with open(json_file, "w") as f:
+        f.write(json.dumps({"text": "s1", "label": "fact"}) + "\n")
+        f.write('{"text": "s2", "label": "emotion"\n')
+
+    with pytest.raises(ValueError, match="Malformed JSON on line 2"):
+        DatasetLoader.load_json(str(json_file), "text", "label")
+
+
+def test_dataset_loader_json_reports_missing_key(tmp_path):
+    """load_json() should report missing expected keys with the failing line."""
+    json_file = tmp_path / "data.jsonl"
+    with open(json_file, "w") as f:
+        f.write(json.dumps({"text": "s1"}) + "\n")
+
+    with pytest.raises(
+        ValueError,
+        match="Missing required JSON key\\(s\\) on line 1: label",
+    ):
+        DatasetLoader.load_json(str(json_file), "text", "label")
+
+
 def test_create_dataloader_batches():
     """create_dataloader() should yield batches with correctly shaped label tensors."""
     vocab = VocabBuilder()


### PR DESCRIPTION
Fixes #118

## Changes
- wrap malformed JSONL lines in a `ValueError` that includes the line number
- report missing `text_key` / `label_key` values with the failing line and expected keys
- add regression tests for both cases

## Verification
- `$env:PYTHONPATH='src'; python -m pytest tests/test_loader.py`
- `$env:PYTHONPATH='src'; python -m pytest`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error messages when loading datasets to include specific line numbers where issues occur, simplifying identification of malformed JSON and missing required fields.

* **Tests**
  * Added test coverage for error handling scenarios including malformed JSON detection and validation of required data fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/skeval-ai/skeval/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->