### PR TITLE
test(skeval/examples): test coverage for examples

### DIFF
--- a/examples/05_load_from_file.py
+++ b/examples/05_load_from_file.py
@@ -61,8 +61,8 @@ with tempfile.TemporaryDirectory() as tmpdir:
     print(f"Loaded {len(train_sentences)} training samples from CSV.")
 
     # --- Train ---
-    classifier = SentenceClassifier(embed_dim=64)
-    classifier.train(train_sentences, train_labels, epochs=30, lr=0.01)
+    classifier = SentenceClassifier(embed_dim=64, epochs=30, lr=0.01)
+    classifier.fit(train_sentences, train_labels)
 
     # --- Load from JSONL ---
     test_sentences, test_labels = DatasetLoader.load_json(jsonl_path, "text", "label")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -7,6 +7,7 @@ EXAMPLES_DIR = Path(__file__).parents[1] / "examples"
 
 
 def _example_files():
+    """Return all Python example files sorted by name."""
     return sorted(EXAMPLES_DIR.glob("*.py"))
 
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,28 @@
+import ast
+from pathlib import Path
+
+import pytest
+
+EXAMPLES_DIR = Path(__file__).parents[1] / "examples"
+
+
+def _example_files():
+    return sorted(EXAMPLES_DIR.glob("*.py"))
+
+
+@pytest.mark.parametrize("path", _example_files(), ids=lambda p: p.name)
+def test_example_uses_fit_not_train(path):
+    """Each example file must call .fit() and must not call deprecated .train()."""
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(path))
+
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "train"
+        ):
+            raise AssertionError(
+                f"{path.name} line {node.lineno}: deprecated .train() call found. "
+                "Use .fit() instead."
+            )


### PR DESCRIPTION
Closes #120

Picked up issue #120. A few example files were still calling the deprecated `.train()` method even after the quickstart was fixed. Updated 02, 03, 04, and 05 to use `.fit()` with hyperparams moved to the constructor, the way the sklearn-style API expects it.

Also added `tests/test_examples.py` so this can't quietly regress. It uses AST parsing to check each example file, so it won't false-positive on variable names like `train_sentences` or `train.csv`.

Tests passing screenshot below 👇

<img width="1320" height="857" alt="image" src="https://github.com/user-attachments/assets/b4f9adef-dbd7-48b2-bf2c-5e0db729ef09" />
