### PR TITLE
fix(skeval/examples): replace deprecated `train()` with `fit()` in `03_evaluation.py`

### DIFF
--- a/examples/03_evaluation.py
+++ b/examples/03_evaluation.py
@@ -34,8 +34,8 @@ train_labels = [
     "instruction",
 ]
 
-classifier = SentenceClassifier(embed_dim=64)
-classifier.train(train_sentences, train_labels, epochs=40, lr=0.01)
+classifier = SentenceClassifier(embed_dim=64, epochs=40, lr=0.01)
+classifier.fit(train_sentences, train_labels)
 
 test_sentences = [
     "The sky is blue",


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #107

#### What does this implement/fix?
`examples/03_evaluation.py` called the deprecated `SentenceClassifier.train()` method, which is scheduled for removal in v0.3.0. This PR moves `epochs` and `lr` to the `SentenceClassifier` constructor and switches the training call to `fit()`, matching the pattern already applied in `examples/01_quickstart.py` (#112) and `docs/usage.rst` (#126).

---

#### Checklist

**Code changes**
- [x] My code follows the project style (`black`, `isort`, `flake8`)
- [x] All existing tests pass locally (`pytest tests/`) — 99 passed, 30 skipped
- [x] I have added type annotations where applicable


---

#### AI usage disclosure
I used AI assistance for:
- [x] Code generation
- [x] Research and understanding

---

#### Any other comments?
No new tests added this is a one-line example update that already exercises the public API. Verified locally with `python -W error::DeprecationWarning examples/03_evaluation.py`, which now runs cleanly with no `DeprecationWarning`.

<img width="1370" height="798" alt="image" src="https://github.com/user-attachments/assets/52cb37c5-cb0e-4413-bdb9-ad3ccbd5a155" />

