### PR TITLE
fix(skeval/examples): replace deprecated `train()` with `fit()` in `04_custom_labels.py`

### DIFF
--- a/examples/04_custom_labels.py
+++ b/examples/04_custom_labels.py
@@ -37,8 +37,8 @@ labels = [
     "complaint",
 ]
 
-classifier = SentenceClassifier(embed_dim=32)
-classifier.train(sentences, labels, epochs=40, lr=0.01)
+classifier = SentenceClassifier(embed_dim=32, epochs=40, lr=0.01)
+classifier.fit(sentences, labels)
 
 test_sentences = [
     "My parcel is lost",


### PR DESCRIPTION
fixes #108