### PR TITLE
chore(skeval/docs): pin exact doc-build dependencies for reproducible RTD builds  

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,5 +12,4 @@ python:
   install:
     - method: pip
       path: .
-      extra_requirements:
-        - docs
+    - requirements: docs/requirements-docs.txt

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,0 +1,3 @@
+sphinx==8.1.3
+sphinx-rtd-theme==3.1.0
+myst-parser==4.0.1


### PR DESCRIPTION
fixes #139 