### PR TITLE
fix(skeval/metrics): single-label confusion matrix produces wrong shape and emits warning  

### DIFF
--- a/src/skeval/evaluator/evaluator.py
+++ b/src/skeval/evaluator/evaluator.py
@@ -30,6 +30,8 @@ class Evaluator:
 
         Raises:
             ValueError: If either list is empty or the lengths do not match.
+            ValueError: If the combined label set contains fewer than 2 distinct
+                values (propagated from ``compute_metrics``).
         """
         if not isinstance(predictions, (list, tuple)) or len(predictions) == 0:
             raise ValueError("predictions must be a non-empty list of strings.")

--- a/src/skeval/metrics/metrics.py
+++ b/src/skeval/metrics/metrics.py
@@ -26,11 +26,18 @@ def compute_metrics(y_true: List[str], y_pred: List[str]) -> Dict[str, Any]:
     """
     acc = accuracy_score(y_true, y_pred)
 
-    # zero_division=0 prevents warnings if a class is never predicted
-    report = classification_report(y_true, y_pred, output_dict=True, zero_division=0)
-
-    # Extract unique labels in sorted order to map the confusion matrix
+    # Sorted union of all labels seen in either input
     labels = sorted(list(set(y_true) | set(y_pred)))
+
+    if len(labels) < 2:
+        raise ValueError(
+            f"compute_metrics requires at least 2 distinct labels, got: {labels}"
+        )
+
+    # zero_division=0 prevents warnings if a class is never predicted
+    report = classification_report(
+        y_true, y_pred, labels=labels, output_dict=True, zero_division=0
+    )
     cm = confusion_matrix(y_true, y_pred, labels=labels)
 
     return {

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,3 +1,5 @@
+import pytest
+
 from skeval.metrics import compute_metrics
 
 
@@ -73,7 +75,6 @@ def test_compute_metrics_macro_avg_present():
 
 
 def test_compute_metrics_single_class():
-    """compute_metrics should work correctly when only one class is present."""
-    results = compute_metrics(["fact", "fact"], ["fact", "fact"])
-    assert results["accuracy"] == 1.0
-    assert "fact" in results["per_class"]
+    """compute_metrics must raise ValueError when only one distinct label is present."""
+    with pytest.raises(ValueError, match="at least 2 distinct labels"):
+        compute_metrics(["fact", "fact"], ["fact", "fact"])


### PR DESCRIPTION

#### Reference Issues/PRs
Fixes #131 

#### What does this implement/fix?
as confusion matrix needs more than one able so the warnign was raised by tests insedte we will not accept a single matrix and raise a `ValueError` 

#### Checklist

**Code changes**
- [x] My code follows the project style (`black`, `isort`, `flake8`)
- [x] I have added or updated tests to cover my changes
- [x] All existing tests pass locally (`pytest tests/`)
- [ ] I have added type annotations where applicable

**Documentation**
- [ ] I have updated the relevant docstrings
- [ ] I have updated `docs/` or `README.md` if the public API or behaviour changed
- [ ] I have updated `docs/changelog.rst` with a summary of my change

**General**
- [x] My branch is up to date with `main`
- [x] I have linked the related issue above
- [x] I have kept this PR focused (one issue per PR)

---

#### AI usage disclosure
<!--
If AI tools were involved, check all that apply.
-->
I used AI assistance for:
- [ ] Code generation (e.g., writing an implementation or fixing a bug)
- [x] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

---

#### Any other comments?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced metrics computation to enforce a minimum requirement of two distinct labels. The system now raises an error when fewer than two distinct labels are detected, ensuring accurate and reliable classification metric calculations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/skeval-ai/skeval/pull/152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->