### PR TITLE
fix(skeval/examples): skore api change

### DIFF
--- a/examples/07_skore.py
+++ b/examples/07_skore.py
@@ -44,7 +44,7 @@ baseline = skore.CrossValidationReport(
     SentenceClassifier(embed_dim=64, epochs=40, lr=0.01, random_state=42),
     X=sentences,
     y=labels,
-    cv=2,
+    splitter=2,
 )
 print(baseline.metrics.summarize())
 

--- a/examples/07_skore.py
+++ b/examples/07_skore.py
@@ -25,6 +25,16 @@ class SkoreClassifier(SentenceClassifier):
     """Thin wrapper that adds classes_ for skore tool compatibility."""
 
     def fit(self, X, y):
+        """
+        Fit the classifier on training data and ensure a populated `classes_` attribute.
+        
+        Parameters:
+            X (array-like): Sequence of input texts to train on.
+            y (array-like): Sequence of target labels aligned with `X`.
+        
+        Returns:
+            SkoreClassifier: The fitted estimator with `classes_` set to the sorted unique labels from `y`.
+        """
         super().fit(X, y)
         self.classes_ = np.array(sorted(set(y)))
         return self

--- a/examples/07_skore.py
+++ b/examples/07_skore.py
@@ -2,7 +2,7 @@
 
 skore is an open-source ML experiment tracker that works with any
 sklearn-compatible estimator.  This example shows how to use skore's
-CrossValidationReport and ComparisonReport to inspect and compare
+EstimatorReport and ComparisonReport to inspect and compare
 SentenceClassifier configurations.
 
 Install skore first:
@@ -16,6 +16,7 @@ import skore
 from sklearn.exceptions import UndefinedMetricWarning
 
 from skeval.classifier import SentenceClassifier
+from skeval.model_selection import train_test_split
 
 warnings.filterwarnings("ignore", category=UndefinedMetricWarning)
 
@@ -27,6 +28,7 @@ class SkoreClassifier(SentenceClassifier):
         super().fit(X, y)
         self.classes_ = np.array(sorted(set(y)))
         return self
+
 
 sentences = [
     # fact (10)
@@ -81,17 +83,24 @@ labels = (
     + ["instruction"] * 10
 )
 
-# --- cross-validated baseline ---
-print("Running cross-validation baseline...")
-baseline = skore.CrossValidationReport(
-    SkoreClassifier(embed_dim=64, epochs=40, lr=0.01, random_state=42),
-    X=sentences,
-    y=labels,
-    splitter=2,
+# --- train / test split ---
+X_train, X_test, y_train, y_test = train_test_split(
+    sentences, labels, test_size=0.25, random_state=42
 )
-print(f"Accuracy:  {baseline.metrics.accuracy()}")
-print(f"Precision: {baseline.metrics.precision()}")
-print(f"Recall:    {baseline.metrics.recall()}")
+
+# --- baseline report ---
+print("Training baseline model...")
+baseline_clf = SkoreClassifier(embed_dim=64, epochs=40, lr=0.01, random_state=42)
+baseline_clf.fit(X_train, y_train)
+
+baseline = skore.EstimatorReport(
+    baseline_clf,
+    X_train=X_train,
+    y_train=y_train,
+    X_test=X_test,
+    y_test=y_test,
+)
+print(f"Baseline accuracy: {baseline.metrics.accuracy()}")
 
 # --- compare hyperparameter configurations ---
 print("\nComparing hyperparameter configurations...")
@@ -104,7 +113,14 @@ for embed_dim in [32, 64]:
             lr=lr,
             random_state=42,
         )
-        report = skore.CrossValidationReport(clf, X=sentences, y=labels, splitter=2)
+        clf.fit(X_train, y_train)
+        report = skore.EstimatorReport(
+            clf,
+            X_train=X_train,
+            y_train=y_train,
+            X_test=X_test,
+            y_test=y_test,
+        )
         reports.append(report)
 
 comparison = skore.ComparisonReport(reports)

--- a/examples/07_skore.py
+++ b/examples/07_skore.py
@@ -9,58 +9,103 @@ Install skore first:
     pip install skore
 """
 
+import warnings
+
+import numpy as np
 import skore
+from sklearn.exceptions import UndefinedMetricWarning
 
 from skeval.classifier import SentenceClassifier
 
+warnings.filterwarnings("ignore", category=UndefinedMetricWarning)
+
+
+class SkoreClassifier(SentenceClassifier):
+    """Thin wrapper that adds classes_ for skore tool compatibility."""
+
+    def fit(self, X, y):
+        super().fit(X, y)
+        self.classes_ = np.array(sorted(set(y)))
+        return self
+
 sentences = [
+    # fact (10)
     "Water boils at 100 degrees Celsius",
     "Paris is the capital of France",
     "The moon orbits the Earth",
-    "Light travels at 300,000 km per second",
+    "Light travels at 300000 km per second",
+    "The human body has 206 bones",
+    "Oxygen has atomic number 8",
+    "The Great Wall of China is over 21000 km long",
+    "Mount Everest is the tallest mountain on Earth",
+    "The Amazon is the largest river by discharge",
+    "DNA carries genetic information",
+    # emotion (10)
     "I am feeling very sad today",
     "This is the worst day of my life",
     "I feel so excited right now",
     "She was overwhelmed with joy",
+    "I am so angry I cannot think straight",
+    "This makes me incredibly happy",
+    "I feel anxious about the meeting",
+    "He was devastated by the news",
+    "I love spending time with my family",
+    "She felt proud of her achievement",
+    # opinion (10)
     "I think this movie is amazing",
-    "In my opinion, pizza is the best food",
+    "In my opinion pizza is the best food",
     "I believe coffee is better than tea",
-    "Personally, I prefer winter over summer",
+    "Personally I prefer winter over summer",
+    "I think remote work is more productive",
+    "In my view this policy is misguided",
+    "I feel that kindness matters most",
+    "I believe education should be free",
+    "Personally I find classical music relaxing",
+    "I think dogs make better pets than cats",
+    # instruction (10)
     "Please close the door",
     "Open the window right now",
     "Turn off the lights",
     "Send me the report by Monday",
+    "Submit your assignment before Friday",
+    "Click the button to continue",
+    "Add the ingredients and stir well",
+    "Save your work before closing",
+    "Reply to this email within 24 hours",
+    "Install the latest version to proceed",
 ]
-labels = [
-    "fact", "fact", "fact", "fact",
-    "emotion", "emotion", "emotion", "emotion",
-    "opinion", "opinion", "opinion", "opinion",
-    "instruction", "instruction", "instruction", "instruction",
-]
+labels = (
+    ["fact"] * 10
+    + ["emotion"] * 10
+    + ["opinion"] * 10
+    + ["instruction"] * 10
+)
 
 # --- cross-validated baseline ---
 print("Running cross-validation baseline...")
 baseline = skore.CrossValidationReport(
-    SentenceClassifier(embed_dim=64, epochs=40, lr=0.01, random_state=42),
+    SkoreClassifier(embed_dim=64, epochs=40, lr=0.01, random_state=42),
     X=sentences,
     y=labels,
     splitter=2,
 )
-print(baseline.metrics.summarize())
+print(f"Accuracy:  {baseline.metrics.accuracy()}")
+print(f"Precision: {baseline.metrics.precision()}")
+print(f"Recall:    {baseline.metrics.recall()}")
 
 # --- compare hyperparameter configurations ---
 print("\nComparing hyperparameter configurations...")
 reports = []
 for embed_dim in [32, 64]:
     for lr in [0.005, 0.01]:
-        clf = SentenceClassifier(
+        clf = SkoreClassifier(
             embed_dim=embed_dim,
             epochs=40,
             lr=lr,
             random_state=42,
         )
-        report = skore.CrossValidationReport(clf, X=sentences, y=labels, cv=2)
+        report = skore.CrossValidationReport(clf, X=sentences, y=labels, splitter=2)
         reports.append(report)
 
 comparison = skore.ComparisonReport(reports)
-print(comparison.metrics.summarize())
+print(comparison.metrics.accuracy())

--- a/examples/07_skore.py
+++ b/examples/07_skore.py
@@ -1,18 +1,15 @@
 """Tracking experiments with skore.
 
 skore is an open-source ML experiment tracker that works with any
-sklearn-compatible estimator.  This example shows how to log a
-GridSearchCV run and inspect results in the skore UI.
+sklearn-compatible estimator.  This example shows how to use skore's
+CrossValidationReport and ComparisonReport to inspect and compare
+SentenceClassifier configurations.
 
 Install skore first:
     pip install skore
-
-Then launch the UI in a separate terminal:
-    skore launch my_project
 """
 
 import skore
-from sklearn.model_selection import GridSearchCV, cross_val_score
 
 from skeval.classifier import SentenceClassifier
 
@@ -41,35 +38,29 @@ labels = [
     "instruction", "instruction", "instruction", "instruction",
 ]
 
-# --- open (or create) a skore project ---
-project = skore.open("my_project", overwrite=True)
-
 # --- cross-validated baseline ---
-clf = SentenceClassifier(embed_dim=64, epochs=40, lr=0.01, random_state=42)
-cv_scores = cross_val_score(clf, sentences, labels, cv=2, scoring="accuracy")
-project.put("baseline_cv_accuracy", cv_scores.mean())
-print(f"Baseline CV accuracy: {cv_scores.mean():.2%}")
-
-# --- grid search ---
-param_grid = {
-    "embed_dim": [32, 64],
-    "epochs": [20, 40],
-    "lr": [0.005, 0.01],
-}
-search = GridSearchCV(
-    SentenceClassifier(random_state=42),
-    param_grid,
+print("Running cross-validation baseline...")
+baseline = skore.CrossValidationReport(
+    SentenceClassifier(embed_dim=64, epochs=40, lr=0.01, random_state=42),
+    X=sentences,
+    y=labels,
     cv=2,
-    scoring="accuracy",
-    n_jobs=1,
-    verbose=0,
 )
-search.fit(sentences, labels)
+print(baseline.metrics.summarize())
 
-project.put("best_params", search.best_params_)
-project.put("best_cv_accuracy", search.best_score_)
+# --- compare hyperparameter configurations ---
+print("\nComparing hyperparameter configurations...")
+reports = []
+for embed_dim in [32, 64]:
+    for lr in [0.005, 0.01]:
+        clf = SentenceClassifier(
+            embed_dim=embed_dim,
+            epochs=40,
+            lr=lr,
+            random_state=42,
+        )
+        report = skore.CrossValidationReport(clf, X=sentences, y=labels, cv=2)
+        reports.append(report)
 
-print(f"Best params  : {search.best_params_}")
-print(f"Best CV acc  : {search.best_score_:.2%}")
-print("\nOpen the skore UI to explore results:")
-print("  skore launch my_project")
+comparison = skore.ComparisonReport(reports)
+print(comparison.metrics.summarize())


### PR DESCRIPTION
there was change in the skore api and now they no longer use the `open()` and the `put()` so this pr updates the examples

now the example shows the estimator report of skore using the custom estimator of skeval
```
Estimator  SkoreClassifier_1  SkoreClassifier_2  SkoreClassifier_3  SkoreClassifier_4
Metric
Accuracy                 0.5                0.6                0.6                0.7
(venv) direk@dkakkar:/mnt/f/skeval/examples$ 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example demonstrating model evaluation using skore/skeval reporting workflow instead of GridSearchCV logging.
  * Example now includes baseline and comparison reports for hyperparameter configurations.
  * Expanded dataset with reformatted training and test data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->