### PR TITLE
feat(skeval): add `encode_padded()` and reserve CLS token

### DIFF
--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -70,10 +70,18 @@ VocabBuilder
 
 Located in :mod:`skeval.utils.helpers`.
 
-Builds a bag-of-words vocabulary from a list of sentences. Text is normalized (lowercased, punctuation stripped) before tokenization. Two special tokens are always present:
+Builds a bag-of-words vocabulary from a list of sentences. Text is normalized (lowercased, punctuation stripped) before tokenization. Three special tokens are permanently reserved:
 
-* ``<PAD>`` at index ``0`` — used as a placeholder for empty inputs
+* ``<PAD>`` at index ``0`` — fills unused positions in padded sequences
 * ``<UNK>`` at index ``1`` — maps words not seen during training
+* ``<CLS>`` at index ``2`` — prepended by :meth:`~skeval.utils.helpers.VocabBuilder.encode_padded` as the sentence-level representation for the Transformer backend
+
+All vocabulary words are assigned indices starting at ``3``.
+
+Two encoding methods are available:
+
+* :meth:`~skeval.utils.helpers.VocabBuilder.encode` — returns a variable-length list of token indices. Used by the ``bow`` backend with ``nn.EmbeddingBag``.
+* :meth:`~skeval.utils.helpers.VocabBuilder.encode_padded` — returns a fixed-length list of exactly ``max_len`` indices, prefixed with ``<CLS>`` and right-padded with ``<PAD>``. Used by the ``transformer`` backend.
 
 The ``min_freq`` parameter (default ``1``) filters out rare tokens. The ``word2idx`` and ``idx2word`` mappings are built in a single pass over the corpus for efficiency.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,17 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 -------------
 
+Added
+~~~~~
+
+- :meth:`~skeval.utils.helpers.VocabBuilder.encode_padded` — new method that
+  returns a fixed-length ``[CLS]``-prefixed, ``<PAD>``-padded token index list
+  for use by the Transformer backend.
+  See :issue:`155` by :user:`direkkakkar319-ops`.
+- ``<CLS>`` token reserved at index ``2`` in :class:`~skeval.utils.helpers.VocabBuilder`
+  — vocabulary words now start at index ``3`` (previously ``2``).
+  See :issue:`155` by :user:`direkkakkar319-ops`.
+
 ----
 
 .. _0.2.3: https://github.com/skeval-ai/skeval/compare/v0.2.2...v0.2.3

--- a/src/skeval/utils/helpers.py
+++ b/src/skeval/utils/helpers.py
@@ -21,9 +21,17 @@ def normalize_text(text: str) -> str:
 class VocabBuilder:
     """Builds a vocabulary from a text corpus and encodes sentences as indices.
 
-    Tokens 0 and 1 are reserved for ``<PAD>`` and ``<UNK>`` respectively.
-    All other tokens are assigned indices starting at 2 in the order they
-    appear in the counter after filtering by ``min_freq``.
+    Three indices are permanently reserved:
+
+    ======  =======  =====================================================
+    Index   Token    Purpose
+    ======  =======  =====================================================
+    0       <PAD>    Padding — fills unused positions in padded sequences
+    1       <UNK>    Unknown — replaces out-of-vocabulary tokens
+    2       <CLS>    Classification — prepended by ``encode_padded()``
+    ======  =======  =====================================================
+
+    All vocabulary words are assigned indices starting at 3.
 
     Attributes:
         min_freq: Minimum number of occurrences for a token to be included.
@@ -33,16 +41,16 @@ class VocabBuilder:
     """
 
     def __init__(self, min_freq: int = 1) -> None:
-        """Initialise an empty vocabulary.
+        """Initialise an empty vocabulary with the three reserved tokens.
 
         Args:
             min_freq: Tokens appearing fewer than this many times across the
                 corpus are excluded from the vocabulary.
         """
         self.min_freq = min_freq
-        # Reserve 0 for padding, 1 for unknown words
-        self.word2idx: Dict[str, int] = {"<PAD>": 0, "<UNK>": 1}
-        self.idx2word: Dict[int, str] = {0: "<PAD>", 1: "<UNK>"}
+        # 0=<PAD>, 1=<UNK>, 2=<CLS> — all reserved; words start at index 3
+        self.word2idx: Dict[str, int] = {"<PAD>": 0, "<UNK>": 1, "<CLS>": 2}
+        self.idx2word: Dict[int, str] = {0: "<PAD>", 1: "<UNK>", 2: "<CLS>"}
         self.is_built: bool = False
 
     def build(self, sentences: List[str]) -> None:
@@ -80,6 +88,35 @@ class VocabBuilder:
             raise ValueError("Vocabulary has not been built yet. Call build() first.")
         words = normalize_text(sentence).split()
         return [self.word2idx.get(word, self.word2idx["<UNK>"]) for word in words]
+
+    def encode_padded(self, sentence: str, max_len: int) -> List[int]:
+        """Encode a sentence as a ``[CLS]``-prefixed, fixed-length token list.
+
+        Prepends ``<CLS>`` (index 2), encodes up to ``max_len - 1`` words,
+        then right-pads with ``<PAD>`` (index 0) to exactly ``max_len``
+        tokens. Sentences longer than ``max_len - 1`` words are truncated.
+
+        Args:
+            sentence: Raw input sentence.
+            max_len: Total sequence length including the ``<CLS>`` token.
+                Must be at least 2 (room for ``<CLS>`` + one token).
+
+        Returns:
+            List of exactly ``max_len`` integer indices.
+
+        Raises:
+            ValueError: If ``build()`` has not been called yet.
+            ValueError: If ``max_len`` is less than 2.
+        """
+        if not self.is_built:
+            raise ValueError("Vocabulary has not been built yet. Call build() first.")
+        if max_len < 2:
+            raise ValueError(f"max_len must be at least 2 (got {max_len}).")
+        cls_idx = self.word2idx["<CLS>"]
+        pad_idx = self.word2idx["<PAD>"]
+        word_indices = self.encode(sentence)[: max_len - 1]
+        padding = [pad_idx] * (max_len - 1 - len(word_indices))
+        return [cls_idx] + word_indices + padding
 
     def __len__(self) -> int:
         return len(self.word2idx)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,6 @@
-from skeval.utils.helpers import normalize_text
+import pytest
+
+from skeval.utils.helpers import VocabBuilder, normalize_text
 
 
 def test_normalize_text_lowercases():
@@ -24,3 +26,71 @@ def test_normalize_text_empty_string():
 def test_normalize_text_numbers_kept():
     """normalize_text() should preserve numeric characters."""
     assert "100" in normalize_text("Water boils at 100C.")
+
+
+# --- VocabBuilder: reserved token layout ---
+
+
+@pytest.fixture()
+def built_vocab():
+    v = VocabBuilder()
+    v.build(["Water boils at 100C", "I love you"])
+    return v
+
+
+def test_cls_token_reserved_at_index_2():
+    """<CLS> must be present at index 2 before build() is called."""
+    v = VocabBuilder()
+    assert v.word2idx["<CLS>"] == 2
+    assert v.idx2word[2] == "<CLS>"
+
+
+def test_word_indices_start_at_3(built_vocab):
+    """Vocabulary words must be assigned indices starting at 3."""
+    word_indices = [
+        idx
+        for token, idx in built_vocab.word2idx.items()
+        if token not in ("<PAD>", "<UNK>", "<CLS>")
+    ]
+    assert all(idx >= 3 for idx in word_indices)
+    assert min(word_indices) == 3
+
+
+# --- VocabBuilder: encode_padded ---
+
+
+def test_encode_padded_exact_length(built_vocab):
+    """encode_padded() must return exactly max_len elements."""
+    assert len(built_vocab.encode_padded("Water boils", max_len=6)) == 6
+
+
+def test_encode_padded_cls_at_position_0(built_vocab):
+    """encode_padded() must place <CLS> (index 2) at position 0."""
+    result = built_vocab.encode_padded("Water boils", max_len=6)
+    assert result[0] == 2
+
+
+def test_encode_padded_right_padded_with_zeros(built_vocab):
+    """encode_padded() must right-pad short sequences with <PAD> (index 0)."""
+    result = built_vocab.encode_padded("Water", max_len=5)
+    assert result[-1] == 0
+    assert result.count(0) == 3  # max_len - 1 (CLS) - 1 (water) = 3 pads
+
+
+def test_encode_padded_truncates_long_sentences(built_vocab):
+    """encode_padded() must truncate sentences longer than max_len - 1 words."""
+    result = built_vocab.encode_padded("Water boils at 100C I love you", max_len=4)
+    assert len(result) == 4
+
+
+def test_encode_padded_before_build_raises():
+    """encode_padded() must raise ValueError if build() has not been called."""
+    v = VocabBuilder()
+    with pytest.raises(ValueError, match="not been built"):
+        v.encode_padded("hello", max_len=5)
+
+
+def test_encode_padded_max_len_too_small_raises(built_vocab):
+    """encode_padded() must raise ValueError when max_len < 2."""
+    with pytest.raises(ValueError, match="max_len"):
+        built_vocab.encode_padded("hello", max_len=1)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -15,7 +15,7 @@ def test_vocab_builder_basic():
     vocab = VocabBuilder(min_freq=1)
     vocab.build(["Hello world", "Hello there"])
     assert vocab.is_built
-    assert len(vocab) == 5  # <PAD>, <UNK>, hello, world, there
+    assert len(vocab) == 6  # <PAD>, <UNK>, <CLS>, hello, world, there
 
 
 def test_vocab_builder_min_freq():
@@ -68,9 +68,9 @@ def test_vocab_builder_normalises_case():
 
 
 def test_vocab_builder_len():
-    """A freshly created VocabBuilder should have length 2 (<PAD> and <UNK>)."""
+    """A freshly created VocabBuilder should have length 3 (<PAD>, <UNK>, <CLS>)."""
     vocab = VocabBuilder()
-    assert len(vocab) == 2
+    assert len(vocab) == 3
 
 
 # --- LabelEncoder ---


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #155 

#### What does this implement/fix?
here we are starting the tokenizer backend update by updating the tokenizer


#### Checklist

**Code changes**
- [x] My code follows the project style (`black`, `isort`, `flake8`)
- [x] I have added or updated tests to cover my changes
- [x] All existing tests pass locally (`pytest tests/`)
- [x] I have added type annotations where applicable

**Documentation**
- [x] I have updated the relevant docstrings
- [x] I have updated `docs/` or `README.md` if the public API or behaviour changed
- [ ] I have updated `docs/changelog.rst` with a summary of my change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `encode_padded()` method enabling fixed-length encoded sequences with automatic padding and truncation.
  * Introduced `<CLS>` as a new reserved special token for enhanced text encoding.

* **Documentation**
  * Updated VocabBuilder documentation clarifying the distinction between variable-length and fixed-length encoding modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->