### PR TITLE
fix(skeval/src): stop train() from mutating instance hyperparameters

### DIFF
--- a/src/skeval/classifier/sentence_classifier.py
+++ b/src/skeval/classifier/sentence_classifier.py
@@ -402,13 +402,17 @@ class SentenceClassifier(BaseEstimator):  # type: ignore[misc]
             DeprecationWarning,
             stacklevel=2,
         )
+        saved = (self.epochs, self.batch_size, self.lr)
         if epochs is not None:
             self.epochs = epochs
         if batch_size is not None:
             self.batch_size = batch_size
         if lr is not None:
             self.lr = lr
-        return self.fit(sentences, labels)
+        try:
+            return self.fit(sentences, labels)
+        finally:
+            self.epochs, self.batch_size, self.lr = saved
 
     def save(self, save_dir: str) -> None:
         """Persist the trained model and vocabulary metadata to disk.

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -293,22 +293,31 @@ def test_train_still_works():
     assert clf.model is not None
 
 
-def test_train_batch_size_override():
-    """train() must apply batch_size override when provided."""
+def test_train_batch_size_override_does_not_mutate():
+    """train() must use the batch_size override for one call without mutating self."""
     clf = SentenceClassifier(embed_dim=16, batch_size=32)
     with warnings.catch_warnings(record=True):
         warnings.simplefilter("always")
         clf.train(SENTENCES, LABELS, epochs=1, batch_size=8)
-    assert clf.batch_size == 8
+    assert clf.batch_size == 32
 
 
-def test_train_lr_override():
-    """train() must apply lr override when provided."""
+def test_train_lr_override_does_not_mutate():
+    """train() must use the lr override for one call without mutating self."""
     clf = SentenceClassifier(embed_dim=16, lr=0.005)
     with warnings.catch_warnings(record=True):
         warnings.simplefilter("always")
         clf.train(SENTENCES, LABELS, epochs=1, lr=0.123)
-    assert clf.lr == 0.123
+    assert clf.lr == 0.005
+
+
+def test_train_does_not_leak_overrides_into_fit():
+    """A train() override must not affect a subsequent fit() call."""
+    clf = SentenceClassifier(embed_dim=16, epochs=10)
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        clf.train(SENTENCES, LABELS, epochs=1)
+    assert clf.epochs == 10
 
 
 def test_fit_y_non_string_raises():

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -311,13 +311,24 @@ def test_train_lr_override_does_not_mutate():
     assert clf.lr == 0.005
 
 
-def test_train_does_not_leak_overrides_into_fit():
-    """train() override must not affect a subsequent fit() call."""
+def test_train_epochs_override_does_not_mutate():
+    """train() must use the epochs override for one call without mutating self."""
     clf = SentenceClassifier(embed_dim=16, epochs=10)
     with warnings.catch_warnings(record=True):
         warnings.simplefilter("always")
         clf.train(SENTENCES, LABELS, epochs=1)
     assert clf.epochs == 10
+
+
+def test_train_does_not_leak_overrides_into_fit():
+    """train() call passing all overrides must not mutate any of them."""
+    clf = SentenceClassifier(embed_dim=16, epochs=10, batch_size=32, lr=0.005)
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        clf.train(SENTENCES, LABELS, epochs=1, batch_size=8, lr=0.123)
+    assert clf.epochs == 10
+    assert clf.batch_size == 32
+    assert clf.lr == 0.005
 
 
 def test_fit_y_non_string_raises():

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -312,7 +312,7 @@ def test_train_lr_override_does_not_mutate():
 
 
 def test_train_does_not_leak_overrides_into_fit():
-    """A train() override must not affect a subsequent fit() call."""
+    """train() override must not affect a subsequent fit() call."""
     clf = SentenceClassifier(embed_dim=16, epochs=10)
     with warnings.catch_warnings(record=True):
         warnings.simplefilter("always")


### PR DESCRIPTION

#### Reference Issues/PRs
Fixes #114

#### What does this implement/fix?
`train()` was permanently overwriting `self.epochs`, `self.batch_size`, and `self.lr` whenever call-time overrides were passed. The override silently leaked into every subsequent `fit()` call, breaking the sklearn estimator contract that hyperparameters set in `__init__` are not mutated at call time.

Fix: snapshot the three attributes before applying overrides, run `fit()` inside a `try`, and restore the snapshot in `finally` so the original state is preserved even if `fit()` raises.

#### Tests run

```bash
.venv/bin/pytest tests/ -v


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where hyperparameter overrides in the `train()` method would permanently modify instance settings. Hyperparameters now correctly revert to their original values after training, even if the process encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->